### PR TITLE
chore: fix Android SoLoader occasional crash on app re-install

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -252,6 +252,7 @@ dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"// From node_modules
+    implementation 'com.facebook.soloader:soloader:0.10.1+'
 
     def isGifEnabled = (findProperty('expo.gif.enabled') ?: "") == "true";
     def isWebpEnabled = (findProperty('expo.webp.enabled') ?: "") == "true";

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,11 @@ allprojects {
             // Android JSC is installed from npm
             url(new File(["node", "--print", "require.resolve('jsc-android/package.json')"].execute(null, rootDir).text.trim(), "../dist"))
         }
+        configurations.all {
+            resolutionStrategy {
+                force "com.facebook.soloader:soloader:0.10.1"
+            }
+        }
 
         google()
         gradlePluginPortal()


### PR DESCRIPTION
## What does this fix ?

tl; dr: Fixes a possible crash on android install which happens on Android 9, 10 & 11.

detailed: At times when the Android app with some app-data is upgraded the app fails to load with these Exceptions and crashes each time the app is opened on device. These logs have are captured [android-onlaunch-crash.txt](https://github.com/ravikp/inji/files/10906304/android-onlaunch-crash.txt) for this bug.

ref: https://github.com/facebook/SoLoader/issues/77

fixes: https://github.com/mosip/inji/issues/622