### PR TITLE
feat(#669): reload receive state machine on navigation of receive screen

### DIFF
--- a/machines/openIdBle/request.ts
+++ b/machines/openIdBle/request.ts
@@ -55,6 +55,7 @@ const model = createModel(
       GO_TO_RECEIVED_VC_TAB: () => ({}),
       REJECT: () => ({}),
       CANCEL: () => ({}),
+      RESET: () => ({}),
       DISMISS: () => ({}),
       VC_RECEIVED: (vc: VC) => ({ vc }),
       CONNECTION_DESTROYED: () => ({}),
@@ -109,6 +110,7 @@ export const requestMachine =
           target: '.inactive',
         },
         SCREEN_FOCUS: {
+          // eslint-disable-next-line sonarjs/no-duplicate-string
           target: '.checkingBluetoothService',
         },
         SWITCH_PROTOCOL: {
@@ -117,6 +119,9 @@ export const requestMachine =
         },
         BLE_ERROR: {
           target: '.handlingBleError',
+        },
+        RESET: {
+          target: '.checkingBluetoothService',
         },
       },
       states: {
@@ -912,6 +917,10 @@ export function selectIsAccepting(state: State) {
 
 export function selectIsSavingFailedInIdle(state: State) {
   return state.matches('reviewing.savingFailed.idle');
+}
+
+export function selectIsSavingFailedInViewingVc(state: State) {
+  return state.matches('reviewing.savingFailed.viewingVc');
 }
 
 export function selectStoreError(state: State) {

--- a/machines/openIdBle/request.typegen.ts
+++ b/machines/openIdBle/request.typegen.ts
@@ -1,84 +1,182 @@
+// This file was automatically generated. Edits will be overwritten
 
-  // This file was automatically generated. Edits will be overwritten
-
-  export interface Typegen0 {
-        '@@xstate/typegen': true;
-        internalEvents: {
-          "": { type: "" };
-"done.invoke.request.reviewing.verifyingVp:invocation[0]": { type: "done.invoke.request.reviewing.verifyingVp:invocation[0]"; data: unknown; __tip: "See the XState TS docs to learn how to strongly type this." };
-"xstate.after(CONNECTION_TIMEOUT)#request.exchangingDeviceInfo.inProgress": { type: "xstate.after(CONNECTION_TIMEOUT)#request.exchangingDeviceInfo.inProgress" };
-"xstate.after(DESTROY_TIMEOUT)#request.clearingConnection": { type: "xstate.after(DESTROY_TIMEOUT)#request.clearingConnection" };
-"xstate.after(SHARING_TIMEOUT)#request.waitingForVc.inProgress": { type: "xstate.after(SHARING_TIMEOUT)#request.waitingForVc.inProgress" };
-"xstate.init": { type: "xstate.init" };
-"xstate.stop": { type: "xstate.stop" };
-        };
-        invokeSrcNameMap: {
-          "advertiseDevice": "done.invoke.request.waitingForConnection:invocation[0]";
-"checkBluetoothService": "done.invoke.request.checkingBluetoothService.checking:invocation[0]";
-"disconnect": "done.invoke.request.clearingConnection:invocation[0]" | "done.invoke.request.reviewing.navigatingToHome:invocation[0]";
-"exchangeDeviceInfo": "done.invoke.request.exchangingDeviceInfo:invocation[0]";
-"monitorConnection": "done.invoke.request:invocation[0]";
-"receiveVc": "done.invoke.request.waitingForVc:invocation[0]";
-"requestBluetooth": "done.invoke.request.checkingBluetoothService.requesting:invocation[0]";
-"sendDisconnect": "done.invoke.request.cancelling:invocation[0]";
-"sendVcResponse": "done.invoke.request.reviewing.accepted:invocation[0]" | "done.invoke.request.reviewing.rejected:invocation[0]" | "done.invoke.request.reviewing.savingFailed:invocation[0]";
-"verifyVp": "done.invoke.request.reviewing.verifyingVp:invocation[0]";
-        };
-        missingImplementations: {
-          actions: never;
-          delays: never;
-          guards: never;
-          services: never;
-        };
-        eventsCausingActions: {
-          "clearShouldVerifyPresence": "ACCEPT" | "BLE_ERROR" | "CANCEL" | "FACE_INVALID" | "FACE_VALID" | "REJECT" | "SCREEN_BLUR" | "SCREEN_FOCUS" | "SWITCH_PROTOCOL" | "xstate.stop";
-"generateConnectionParams": "CONNECTION_DESTROYED" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#request.clearingConnection";
-"logReceived": "CANCEL" | "REJECT" | "STORE_ERROR" | "STORE_RESPONSE";
-"mergeIncomingVc": "STORE_RESPONSE";
-"openSettings": "GOTO_SETTINGS";
-"prependReceivedVc": "VC_RESPONSE";
-"registerLoggers": "CONNECTION_DESTROYED" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#request.clearingConnection";
-"removeLoggers": "CONNECTION_DESTROYED" | "DISMISS" | "SCREEN_BLUR" | "xstate.after(DESTROY_TIMEOUT)#request.clearingConnection" | "xstate.init";
-"requestExistingVc": "VC_RESPONSE";
-"requestReceivedVcs": "ACCEPT" | "DISMISS" | "FACE_VALID" | "VC_RECEIVED" | "done.invoke.request.reviewing.verifyingVp:invocation[0]";
-"requestReceiverInfo": "CONNECTED";
-"sendVcReceived": "STORE_RESPONSE";
-"setIncomingVc": "VC_RECEIVED";
-"setReceiveLogTypeDiscarded": "CANCEL" | "REJECT" | "STORE_ERROR";
-"setReceiveLogTypeRegular": "ACCEPT" | "STORE_RESPONSE";
-"setReceiveLogTypeUnverified": "FACE_INVALID";
-"setReceiveLogTypeVerified": "FACE_VALID";
-"setReceiverInfo": "RECEIVE_DEVICE_INFO";
-"setSenderInfo": "EXCHANGE_DONE";
-"setStoringError": "STORE_ERROR";
-"storeVc": "STORE_RESPONSE";
-"switchProtocol": "SWITCH_PROTOCOL";
-        };
-        eventsCausingDelays: {
-          "CONNECTION_TIMEOUT": "RECEIVE_DEVICE_INFO";
-"DESTROY_TIMEOUT": "" | "DISMISS";
-"SHARING_TIMEOUT": "EXCHANGE_DONE";
-        };
-        eventsCausingGuards: {
-          "hasExistingVc": "VC_RESPONSE";
-        };
-        eventsCausingServices: {
-          "advertiseDevice": "CONNECTION_DESTROYED" | "DISMISS" | "xstate.after(DESTROY_TIMEOUT)#request.clearingConnection";
-"checkBluetoothService": "SCREEN_FOCUS" | "SWITCH_PROTOCOL";
-"disconnect": "" | "DISMISS" | "GO_TO_RECEIVED_VC_TAB";
-"exchangeDeviceInfo": "RECEIVE_DEVICE_INFO";
-"monitorConnection": "xstate.init";
-"receiveVc": "EXCHANGE_DONE";
-"requestBluetooth": "BLUETOOTH_DISABLED";
-"sendDisconnect": "CANCEL";
-"sendVcResponse": "CANCEL" | "REJECT" | "STORE_ERROR" | "STORE_RESPONSE";
-"verifyVp": never;
-        };
-        matchesStates: "bluetoothDenied" | "cancelling" | "checkingBluetoothService" | "checkingBluetoothService.checking" | "checkingBluetoothService.enabled" | "checkingBluetoothService.requesting" | "clearingConnection" | "disconnected" | "exchangingDeviceInfo" | "exchangingDeviceInfo.inProgress" | "exchangingDeviceInfo.timeout" | "handlingBleError" | "inactive" | "preparingToExchangeInfo" | "reviewing" | "reviewing.accepted" | "reviewing.accepting" | "reviewing.accepting.mergingIncomingVc" | "reviewing.accepting.prependingReceivedVc" | "reviewing.accepting.requestingExistingVc" | "reviewing.accepting.requestingReceivedVcs" | "reviewing.accepting.storingVc" | "reviewing.idle" | "reviewing.invalidIdentity" | "reviewing.navigatingToHome" | "reviewing.rejected" | "reviewing.savingFailed" | "reviewing.savingFailed.idle" | "reviewing.savingFailed.viewingVc" | "reviewing.verifyingIdentity" | "reviewing.verifyingVp" | "waitingForConnection" | "waitingForVc" | "waitingForVc.inProgress" | "waitingForVc.timeout" | { "checkingBluetoothService"?: "checking" | "enabled" | "requesting";
-"exchangingDeviceInfo"?: "inProgress" | "timeout";
-"reviewing"?: "accepted" | "accepting" | "idle" | "invalidIdentity" | "navigatingToHome" | "rejected" | "savingFailed" | "verifyingIdentity" | "verifyingVp" | { "accepting"?: "mergingIncomingVc" | "prependingReceivedVc" | "requestingExistingVc" | "requestingReceivedVcs" | "storingVc";
-"savingFailed"?: "idle" | "viewingVc"; };
-"waitingForVc"?: "inProgress" | "timeout"; };
-        tags: never;
-      }
-  
+export interface Typegen0 {
+  '@@xstate/typegen': true;
+  'internalEvents': {
+    '': { type: '' };
+    'done.invoke.request.reviewing.verifyingVp:invocation[0]': {
+      type: 'done.invoke.request.reviewing.verifyingVp:invocation[0]';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
+    'xstate.after(CONNECTION_TIMEOUT)#request.exchangingDeviceInfo.inProgress': {
+      type: 'xstate.after(CONNECTION_TIMEOUT)#request.exchangingDeviceInfo.inProgress';
+    };
+    'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection': {
+      type: 'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection';
+    };
+    'xstate.after(SHARING_TIMEOUT)#request.waitingForVc.inProgress': {
+      type: 'xstate.after(SHARING_TIMEOUT)#request.waitingForVc.inProgress';
+    };
+    'xstate.init': { type: 'xstate.init' };
+    'xstate.stop': { type: 'xstate.stop' };
+  };
+  'invokeSrcNameMap': {
+    advertiseDevice: 'done.invoke.request.waitingForConnection:invocation[0]';
+    checkBluetoothService: 'done.invoke.request.checkingBluetoothService.checking:invocation[0]';
+    disconnect:
+      | 'done.invoke.request.clearingConnection:invocation[0]'
+      | 'done.invoke.request.reviewing.navigatingToHome:invocation[0]';
+    exchangeDeviceInfo: 'done.invoke.request.exchangingDeviceInfo:invocation[0]';
+    monitorConnection: 'done.invoke.request:invocation[0]';
+    receiveVc: 'done.invoke.request.waitingForVc:invocation[0]';
+    requestBluetooth: 'done.invoke.request.checkingBluetoothService.requesting:invocation[0]';
+    sendDisconnect: 'done.invoke.request.cancelling:invocation[0]';
+    sendVcResponse:
+      | 'done.invoke.request.reviewing.accepted:invocation[0]'
+      | 'done.invoke.request.reviewing.rejected:invocation[0]'
+      | 'done.invoke.request.reviewing.savingFailed:invocation[0]';
+    verifyVp: 'done.invoke.request.reviewing.verifyingVp:invocation[0]';
+  };
+  'missingImplementations': {
+    actions: never;
+    delays: never;
+    guards: never;
+    services: never;
+  };
+  'eventsCausingActions': {
+    clearShouldVerifyPresence:
+      | 'ACCEPT'
+      | 'BLE_ERROR'
+      | 'CANCEL'
+      | 'FACE_INVALID'
+      | 'FACE_VALID'
+      | 'REJECT'
+      | 'RESET'
+      | 'SCREEN_BLUR'
+      | 'SCREEN_FOCUS'
+      | 'SWITCH_PROTOCOL'
+      | 'xstate.stop';
+    generateConnectionParams:
+      | 'CONNECTION_DESTROYED'
+      | 'DISMISS'
+      | 'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection';
+    logReceived: 'CANCEL' | 'REJECT' | 'STORE_ERROR' | 'STORE_RESPONSE';
+    mergeIncomingVc: 'STORE_RESPONSE';
+    openSettings: 'GOTO_SETTINGS';
+    prependReceivedVc: 'VC_RESPONSE';
+    registerLoggers:
+      | 'CONNECTION_DESTROYED'
+      | 'DISMISS'
+      | 'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection';
+    removeLoggers:
+      | 'CONNECTION_DESTROYED'
+      | 'DISMISS'
+      | 'SCREEN_BLUR'
+      | 'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection'
+      | 'xstate.init';
+    requestExistingVc: 'VC_RESPONSE';
+    requestReceivedVcs:
+      | 'ACCEPT'
+      | 'DISMISS'
+      | 'FACE_VALID'
+      | 'VC_RECEIVED'
+      | 'done.invoke.request.reviewing.verifyingVp:invocation[0]';
+    requestReceiverInfo: 'CONNECTED';
+    sendVcReceived: 'STORE_RESPONSE';
+    setIncomingVc: 'VC_RECEIVED';
+    setReceiveLogTypeDiscarded: 'CANCEL' | 'REJECT' | 'STORE_ERROR';
+    setReceiveLogTypeRegular: 'ACCEPT' | 'STORE_RESPONSE';
+    setReceiveLogTypeUnverified: 'FACE_INVALID';
+    setReceiveLogTypeVerified: 'FACE_VALID';
+    setReceiverInfo: 'RECEIVE_DEVICE_INFO';
+    setSenderInfo: 'EXCHANGE_DONE';
+    setStoringError: 'STORE_ERROR';
+    storeVc: 'STORE_RESPONSE';
+    switchProtocol: 'SWITCH_PROTOCOL';
+  };
+  'eventsCausingDelays': {
+    CONNECTION_TIMEOUT: 'RECEIVE_DEVICE_INFO';
+    DESTROY_TIMEOUT: '' | 'DISMISS';
+    SHARING_TIMEOUT: 'EXCHANGE_DONE';
+  };
+  'eventsCausingGuards': {
+    hasExistingVc: 'VC_RESPONSE';
+  };
+  'eventsCausingServices': {
+    advertiseDevice:
+      | 'CONNECTION_DESTROYED'
+      | 'DISMISS'
+      | 'xstate.after(DESTROY_TIMEOUT)#request.clearingConnection';
+    checkBluetoothService: 'RESET' | 'SCREEN_FOCUS' | 'SWITCH_PROTOCOL';
+    disconnect: '' | 'DISMISS' | 'GO_TO_RECEIVED_VC_TAB';
+    exchangeDeviceInfo: 'RECEIVE_DEVICE_INFO';
+    monitorConnection: 'xstate.init';
+    receiveVc: 'EXCHANGE_DONE';
+    requestBluetooth: 'BLUETOOTH_DISABLED';
+    sendDisconnect: 'CANCEL';
+    sendVcResponse: 'CANCEL' | 'REJECT' | 'STORE_ERROR' | 'STORE_RESPONSE';
+    verifyVp: never;
+  };
+  'matchesStates':
+    | 'bluetoothDenied'
+    | 'cancelling'
+    | 'checkingBluetoothService'
+    | 'checkingBluetoothService.checking'
+    | 'checkingBluetoothService.enabled'
+    | 'checkingBluetoothService.requesting'
+    | 'clearingConnection'
+    | 'disconnected'
+    | 'exchangingDeviceInfo'
+    | 'exchangingDeviceInfo.inProgress'
+    | 'exchangingDeviceInfo.timeout'
+    | 'handlingBleError'
+    | 'inactive'
+    | 'preparingToExchangeInfo'
+    | 'reviewing'
+    | 'reviewing.accepted'
+    | 'reviewing.accepting'
+    | 'reviewing.accepting.mergingIncomingVc'
+    | 'reviewing.accepting.prependingReceivedVc'
+    | 'reviewing.accepting.requestingExistingVc'
+    | 'reviewing.accepting.requestingReceivedVcs'
+    | 'reviewing.accepting.storingVc'
+    | 'reviewing.idle'
+    | 'reviewing.invalidIdentity'
+    | 'reviewing.navigatingToHome'
+    | 'reviewing.rejected'
+    | 'reviewing.savingFailed'
+    | 'reviewing.savingFailed.idle'
+    | 'reviewing.savingFailed.viewingVc'
+    | 'reviewing.verifyingIdentity'
+    | 'reviewing.verifyingVp'
+    | 'waitingForConnection'
+    | 'waitingForVc'
+    | 'waitingForVc.inProgress'
+    | 'waitingForVc.timeout'
+    | {
+        checkingBluetoothService?: 'checking' | 'enabled' | 'requesting';
+        exchangingDeviceInfo?: 'inProgress' | 'timeout';
+        reviewing?:
+          | 'accepted'
+          | 'accepting'
+          | 'idle'
+          | 'invalidIdentity'
+          | 'navigatingToHome'
+          | 'rejected'
+          | 'savingFailed'
+          | 'verifyingIdentity'
+          | 'verifyingVp'
+          | {
+              accepting?:
+                | 'mergingIncomingVc'
+                | 'prependingReceivedVc'
+                | 'requestingExistingVc'
+                | 'requestingReceivedVcs'
+                | 'storingVc';
+              savingFailed?: 'idle' | 'viewingVc';
+            };
+        waitingForVc?: 'inProgress' | 'timeout';
+      };
+  'tags': never;
+}

--- a/machines/request.ts
+++ b/machines/request.ts
@@ -57,6 +57,7 @@ const model = createModel(
       GO_TO_RECEIVED_VC_TAB: () => ({}),
       CANCEL: () => ({}),
       DISMISS: () => ({}),
+      RESET: () => ({}),
       VC_RECEIVED: (vc: VC) => ({ vc }),
       CONNECTED: (pairId?: string) => ({ pairId: pairId || '' }),
       DISCONNECT: () => ({}),

--- a/screens/Request/RequestLayout.tsx
+++ b/screens/Request/RequestLayout.tsx
@@ -22,6 +22,13 @@ export const RequestLayout: React.FC = () => {
     <React.Fragment>
       <RequestStack.Navigator
         initialRouteName="RequestScreen"
+        screenListeners={{
+          state: () => {
+            if (controller.IsSavingFailedInViewingVc || controller.isAccepted) {
+              controller.RESET();
+            }
+          },
+        }}
         screenOptions={{
           headerTitleAlign: 'center',
           headerShadowVisible: false,

--- a/screens/Request/RequestLayoutController.ts
+++ b/screens/Request/RequestLayoutController.ts
@@ -15,6 +15,7 @@ import { selectVcLabel } from '../../machines/settings';
 import { MainBottomTabParamList } from '../../routes/main';
 import { GlobalContext } from '../../shared/GlobalContext';
 import { selectIsHandlingBleError } from '../../machines/openIdBle/scan';
+import { selectIsSavingFailedInViewingVc } from '../../machines/openIdBle/request';
 
 type RequestStackParamList = {
   RequestScreen: undefined;
@@ -71,9 +72,14 @@ export function useRequestLayout() {
     isDisconnected: useSelector(requestService, selectIsDisconnected),
     isBleError: useSelector(requestService, selectIsHandlingBleError),
 
+    IsSavingFailedInViewingVc: useSelector(
+      requestService,
+      selectIsSavingFailedInViewingVc
+    ),
     isReviewing,
     isDone,
 
     DISMISS: () => requestService.send(RequestEvents.DISMISS()),
+    RESET: () => requestService.send(RequestEvents.RESET()),
   };
 }


### PR DESCRIPTION
After VC is auto accepted or discarded, 

If user clicks on request icon in bottom nav bar, User is seeing a white screen instead of QR code. 

This bug has been there even before auto save is introduced. 

