### PR TITLE
fix(#185): [Adityan] fix the get UIN/VID button not working in iOS

### DIFF
--- a/screens/Home/MyVcs/GetVcModal.tsx
+++ b/screens/Home/MyVcs/GetVcModal.tsx
@@ -13,9 +13,7 @@ export const GetVcModal: React.FC<GetVcModalProps> = (props) => {
     <React.Fragment>
       <GetIdInputModal
         service={props.service}
-        isVisible={
-          !controller.isAcceptingOtpInput && !controller.isRequestingCredential
-        }
+        isVisible={controller.isAcceptingUinInput}
         onDismiss={controller.DISMISS}
       />
 

--- a/screens/Home/MyVcs/GetVcModal.tsx
+++ b/screens/Home/MyVcs/GetVcModal.tsx
@@ -13,7 +13,9 @@ export const GetVcModal: React.FC<GetVcModalProps> = (props) => {
     <React.Fragment>
       <GetIdInputModal
         service={props.service}
-        isVisible={true}
+        isVisible={
+          !controller.isAcceptingOtpInput && !controller.isRequestingCredential
+        }
         onDismiss={controller.DISMISS}
       />
 


### PR DESCRIPTION
issue - 185 -  Unable to get UIN/VID using AID.

It was not particularly working in iOS devices. It was mentioned that iOS does not support loading of one modal over another.
I made a fix for that by adding a condition. 