### PR TITLE
fix(#634): [Vijay] show only myVCs in the share screen when scanned  through IDP Portal

### DIFF
--- a/machines/vc.ts
+++ b/machines/vc.ts
@@ -244,6 +244,7 @@ export function selectBindedVcs(state: State) {
   return (Object.keys(state.context.vcs) as Array<string>).filter((key) => {
     var walletBindingResponse = state.context.vcs[key].walletBindingResponse;
     return (
+      state.context.myVcs.includes(key) &&
       walletBindingResponse !== null &&
       walletBindingResponse.walletBindingId !== null &&
       walletBindingResponse.walletBindingId !== ''


### PR DESCRIPTION
**Issue:** 
When Scanning the IDP Portal, In the Sharing Screen all the binded VC's are listed including the Received VC's.

**Expectation :** 
In the Sharing Screen, it must only list the myVc binded VC's. Show only myVCs in the share screen and remove the Received Vc's  when scanned  through IDP Portal.

**Steps To Reproduce :** 
1. Have a VC in the myVCs tab 
2. Activate the VC in the myVC.
3. Get a binded VC shared from another device.
4. Make sure you have VC activated in the MyVC and Received VC and Both Binded.
5. Goto IDP Portal 
6. Scan the QR Code
7. you can see the VC that are available in myVC's and received VC's.