### PR TITLE
fix: show save button as loading while verifying the correctness of the entered url

### DIFF
--- a/components/EditableListItem.tsx
+++ b/components/EditableListItem.tsx
@@ -20,7 +20,13 @@ export const EditableListItem: React.FC<EditableListItemProps> = (props) => {
   }, [props.credentialRegistryResponse]);
 
   return (
-    <ListItem bottomDivider topDivider onPress={() => setIsEditing(true)}>
+    <ListItem
+      bottomDivider
+      topDivider
+      onPress={() => {
+        setIsEditing(true);
+        props.reset && props.reset();
+      }}>
       <Icon
         name={props.Icon}
         containerStyle={Theme.Styles.settingsIconBg}
@@ -109,4 +115,5 @@ interface EditableListItemProps {
   display?: 'none' | 'flex';
   credentialRegistryResponse: string;
   verifiable?: boolean;
+  reset?: () => void;
 }

--- a/components/EditableListItem.tsx
+++ b/components/EditableListItem.tsx
@@ -10,11 +10,13 @@ export const EditableListItem: React.FC<EditableListItemProps> = (props) => {
   const [isEditing, setIsEditing] = useState(false);
   const [newValue, setNewValue] = useState(props.value);
   const [overlayOpened, setOverlayOpened] = useState(true);
+  const [isVerifying, setIsVerifying] = useState(false);
 
   useEffect(() => {
     if (props.credentialRegistryResponse === 'success') {
       closePopup();
     }
+    props.verifiable && setIsVerifying(false);
   }, [props.credentialRegistryResponse]);
 
   return (
@@ -64,7 +66,12 @@ export const EditableListItem: React.FC<EditableListItemProps> = (props) => {
             closePopup()}
           <Row>
             <Button fill type="clear" title={t('cancel')} onPress={dismiss} />
-            <Button fill title={t('save')} onPress={edit} />
+            <Button
+              fill
+              title={t('save')}
+              onPress={edit}
+              loading={isVerifying}
+            />
           </Row>
         </Column>
       </Overlay>
@@ -72,6 +79,7 @@ export const EditableListItem: React.FC<EditableListItemProps> = (props) => {
   );
 
   function edit() {
+    props.verifiable && setIsVerifying(true);
     props.onEdit(newValue);
     if (props.credentialRegistryResponse === undefined) {
       setIsEditing(false);
@@ -79,12 +87,14 @@ export const EditableListItem: React.FC<EditableListItemProps> = (props) => {
   }
 
   function dismiss() {
+    props.verifiable && setIsVerifying(false);
     setNewValue(props.value);
     setIsEditing(false);
     props.credentialRegistryResponse = '';
   }
 
   function closePopup() {
+    props.verifiable && setIsVerifying(false);
     setIsEditing(false);
     setOverlayOpened(false);
   }
@@ -98,4 +108,5 @@ interface EditableListItemProps {
   onEdit: (newValue: string) => void;
   display?: 'none' | 'flex';
   credentialRegistryResponse: string;
+  verifiable?: boolean;
 }

--- a/machines/settings.ts
+++ b/machines/settings.ts
@@ -31,6 +31,7 @@ const model = createModel(
       UPDATE_CREDENTIAL_REGISTRY: (credentialRegistry: string) => ({
         credentialRegistry,
       }),
+      RESET_CREDENTIAL_REGISTRY_RESPONSE: () => ({}),
       UPDATE_CREDENTIAL_REGISTRY_RESPONSE: (
         credentialRegistryResponse: string
       ) => ({
@@ -84,7 +85,7 @@ export const settingsMachine = model.createMachine(
             actions: ['resetCredentialRegistry'],
             target: 'resetInjiProps',
           },
-          UPDATE_CREDENTIAL_REGISTRY_RESPONSE: {
+          RESET_CREDENTIAL_REGISTRY_RESPONSE: {
             actions: ['resetCredentialRegistry'],
           },
         },

--- a/machines/settings.ts
+++ b/machines/settings.ts
@@ -84,6 +84,9 @@ export const settingsMachine = model.createMachine(
             actions: ['resetCredentialRegistry'],
             target: 'resetInjiProps',
           },
+          UPDATE_CREDENTIAL_REGISTRY_RESPONSE: {
+            actions: ['resetCredentialRegistry'],
+          },
         },
       },
       resetInjiProps: {

--- a/machines/settings.typegen.ts
+++ b/machines/settings.typegen.ts
@@ -25,7 +25,9 @@ export interface Typegen0 {
   };
   'eventsCausingActions': {
     requestStoredContext: 'xstate.init';
-    resetCredentialRegistry: 'UPDATE_CREDENTIAL_REGISTRY';
+    resetCredentialRegistry:
+      | 'UPDATE_CREDENTIAL_REGISTRY'
+      | 'UPDATE_CREDENTIAL_REGISTRY_RESPONSE';
     setContext: 'STORE_RESPONSE';
     storeContext:
       | 'STORE_RESPONSE'

--- a/machines/settings.typegen.ts
+++ b/machines/settings.typegen.ts
@@ -26,8 +26,8 @@ export interface Typegen0 {
   'eventsCausingActions': {
     requestStoredContext: 'xstate.init';
     resetCredentialRegistry:
-      | 'UPDATE_CREDENTIAL_REGISTRY'
-      | 'UPDATE_CREDENTIAL_REGISTRY_RESPONSE';
+      | 'RESET_CREDENTIAL_REGISTRY_RESPONSE'
+      | 'UPDATE_CREDENTIAL_REGISTRY';
     setContext: 'STORE_RESPONSE';
     storeContext:
       | 'STORE_RESPONSE'

--- a/screens/Profile/ProfileScreen.tsx
+++ b/screens/Profile/ProfileScreen.tsx
@@ -129,7 +129,9 @@ export const ProfileScreen: React.FC<MainRouteProps> = (props) => {
             value={controller.credentialRegistry}
             credentialRegistryResponse={controller.credentialRegistryResponse}
             onEdit={controller.UPDATE_CREDENTIAL_REGISTRY}
+            reset={() => controller.UPDATE_CREDENTIAL_REGISTRY_RESPONSE('')}
             Icon="star"
+            verifiable
           />
         )}
         <ListItem bottomDivider onPress={controller.LOGOUT}>

--- a/screens/Profile/ProfileScreen.tsx
+++ b/screens/Profile/ProfileScreen.tsx
@@ -129,7 +129,7 @@ export const ProfileScreen: React.FC<MainRouteProps> = (props) => {
             value={controller.credentialRegistry}
             credentialRegistryResponse={controller.credentialRegistryResponse}
             onEdit={controller.UPDATE_CREDENTIAL_REGISTRY}
-            reset={() => controller.UPDATE_CREDENTIAL_REGISTRY_RESPONSE('')}
+            reset={() => controller.RESET_CREDENTIAL_REGISTRY_RESPONSE()}
             Icon="star"
             verifiable
           />

--- a/screens/Profile/ProfileScreenController.ts
+++ b/screens/Profile/ProfileScreenController.ts
@@ -128,6 +128,9 @@ export function useProfileScreen({ navigation }: MainRouteProps) {
         )
       ),
 
+    RESET_CREDENTIAL_REGISTRY_RESPONSE: () =>
+      settingsService.send(SettingsEvents.RESET_CREDENTIAL_REGISTRY_RESPONSE()),
+
     TOGGLE_BIOMETRIC: (enable: boolean) =>
       settingsService.send(SettingsEvents.TOGGLE_BIOMETRIC_UNLOCK(enable)),
 

--- a/screens/Settings/SettingScreen.tsx
+++ b/screens/Settings/SettingScreen.tsx
@@ -113,6 +113,7 @@ export const SettingScreen: React.FC<SettingProps & MainRouteProps> = (
                 }
                 onEdit={controller.UPDATE_CREDENTIAL_REGISTRY}
                 Icon="star"
+                verifiable
               />
             )}
 

--- a/screens/Settings/SettingScreen.tsx
+++ b/screens/Settings/SettingScreen.tsx
@@ -112,6 +112,7 @@ export const SettingScreen: React.FC<SettingProps & MainRouteProps> = (
                   controller.credentialRegistryResponse
                 }
                 onEdit={controller.UPDATE_CREDENTIAL_REGISTRY}
+                reset={() => controller.UPDATE_CREDENTIAL_REGISTRY_RESPONSE('')}
                 Icon="star"
                 verifiable
               />

--- a/screens/Settings/SettingScreen.tsx
+++ b/screens/Settings/SettingScreen.tsx
@@ -112,7 +112,7 @@ export const SettingScreen: React.FC<SettingProps & MainRouteProps> = (
                   controller.credentialRegistryResponse
                 }
                 onEdit={controller.UPDATE_CREDENTIAL_REGISTRY}
-                reset={() => controller.UPDATE_CREDENTIAL_REGISTRY_RESPONSE('')}
+                reset={() => controller.RESET_CREDENTIAL_REGISTRY_RESPONSE()}
                 Icon="star"
                 verifiable
               />

--- a/screens/Settings/SettingScreenController.ts
+++ b/screens/Settings/SettingScreenController.ts
@@ -133,6 +133,9 @@ export function useSettingsScreen({ navigation }: MainRouteProps) {
         )
       ),
 
+    RESET_CREDENTIAL_REGISTRY_RESPONSE: () =>
+      settingsService.send(SettingsEvents.RESET_CREDENTIAL_REGISTRY_RESPONSE()),
+
     TOGGLE_BIOMETRIC: (enable: boolean) =>
       settingsService.send(SettingsEvents.TOGGLE_BIOMETRIC_UNLOCK(enable)),
 


### PR DESCRIPTION
This fixes the issue of not able to close edit credential registry popup if user tries to save a new url while their previous urls verification is in progress