### PR TITLE
fix(INJI-223): Handle disconnect & reset scan state machine when sharing the vc and click on any tab icons

### DIFF
--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -96,6 +96,7 @@ const model = createModel(
       RETRY_VERIFICATION: () => ({}),
       VP_CREATED: (vp: VerifiablePresentation) => ({ vp }),
       TOGGLE_USER_CONSENT: () => ({}),
+      RESET: () => ({}),
     },
   }
 );
@@ -133,6 +134,9 @@ export const scanMachine =
         BLE_ERROR: {
           target: '.handlingBleError',
           actions: 'setBleError',
+        },
+        RESET: {
+          target: '.checkStorage',
         },
       },
       states: {

--- a/machines/bleShare/scan/scanMachine.ts
+++ b/machines/bleShare/scan/scanMachine.ts
@@ -126,7 +126,7 @@ export const scanMachine =
       initial: 'inactive',
       on: {
         SCREEN_BLUR: {
-          target: '.inactive',
+          target: '#scan.disconnectDevice',
         },
         SCREEN_FOCUS: {
           target: '.checkStorage',
@@ -142,6 +142,16 @@ export const scanMachine =
       states: {
         inactive: {
           entry: 'removeLoggers',
+        },
+        disconnectDevice: {
+          invoke: {
+            src: 'disconnect',
+          },
+          on: {
+            DISCONNECT: {
+              target: '#scan.inactive',
+            },
+          },
         },
         checkStorage: {
           invoke: {

--- a/routes/main.ts
+++ b/routes/main.ts
@@ -25,7 +25,7 @@ const home: TabScreen = {
       }),
   },
 };
-const scan: TabScreen = {
+export const scan: TabScreen = {
   name: 'Scan',
   component: ScanLayout,
   icon: 'qr-code-scanner',

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   BottomTabNavigationOptions,
   createBottomTabNavigator,
@@ -13,10 +13,13 @@ import { Image } from 'react-native';
 import { SettingScreen } from './Settings/SettingScreen';
 import { HelpScreen } from '../components/HelpScreen';
 
+import { GlobalContext } from '../shared/GlobalContext';
 const { Navigator, Screen } = createBottomTabNavigator();
 
 export const MainLayout: React.FC<RootRouteProps> = (props) => {
   const { t } = useTranslation('MainLayout');
+  const { appService } = useContext(GlobalContext);
+  const scanService = appService.children.get('scan');
 
   const options: BottomTabNavigationOptions = {
     headerRight: () => (
@@ -77,6 +80,13 @@ export const MainLayout: React.FC<RootRouteProps> = (props) => {
           key={route.name}
           name={route.name}
           component={route.component}
+          listeners={{
+            tabPress: (e) => {
+              if (route.name == 'Scan') {
+                scanService.send('RESET');
+              }
+            },
+          }}
           options={{
             ...route.options,
             title: t(route.name),

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -4,7 +4,7 @@ import {
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
 import { Icon } from 'react-native-elements';
-import { mainRoutes } from '../routes/main';
+import { mainRoutes, scan } from '../routes/main';
 import { RootRouteProps } from '../routes';
 import { Theme } from '../components/ui/styleUtils';
 import { useTranslation } from 'react-i18next';
@@ -83,7 +83,7 @@ export const MainLayout: React.FC<RootRouteProps> = (props) => {
           component={route.component}
           listeners={{
             tabPress: (e) => {
-              if (route.name == 'Scan') {
+              if (route.name == scan.name) {
                 scanService.send(ScanEvents.RESET());
               }
             },

--- a/screens/MainLayout.tsx
+++ b/screens/MainLayout.tsx
@@ -14,6 +14,7 @@ import { SettingScreen } from './Settings/SettingScreen';
 import { HelpScreen } from '../components/HelpScreen';
 
 import { GlobalContext } from '../shared/GlobalContext';
+import { ScanEvents } from '../machines/bleShare/scan/scanMachine';
 const { Navigator, Screen } = createBottomTabNavigator();
 
 export const MainLayout: React.FC<RootRouteProps> = (props) => {
@@ -83,7 +84,7 @@ export const MainLayout: React.FC<RootRouteProps> = (props) => {
           listeners={{
             tabPress: (e) => {
               if (route.name == 'Scan') {
-                scanService.send('RESET');
+                scanService.send(ScanEvents.RESET());
               }
             },
           }}


### PR DESCRIPTION
- While sharing the VC if we click on scan icon in the bottom tab navigator reset the state machine to show the camera
- While sharing the VC if we click on tab icons other than scan icon disconnect the wallet from the verifier