### PR TITLE
Fix version code error for beta release pipeline

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -157,7 +157,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionName androidGitVersion.name()
-        versionCode androidGitVersion.code()
+        versionCode 1
 
         Properties properties = new Properties()
         properties.load(project.rootProject.file('local.properties').newDataInputStream())

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -55,6 +55,19 @@ lane :android_build_beta do
 
   git_tag = sh('git describe --abbrev=0 --tags --exact-match HEAD').strip
 
+  def convert_tag_to_code(version)
+    parts = version.split('.')
+    version_code = parts[0].to_i * 1000000 + parts[1].to_i * 1000 + parts[2].to_i
+    return version_code
+  end
+
+  versionCode = convert_tag_to_code(git_tag)
+
+  increment_version_code(
+    gradle_file_path: "app/build.gradle",
+    version_code: versionCode
+  )
+
   versionName = "Inji #{git_tag}"
 
   gradle(task: "clean bundleBetaRelease")


### PR DESCRIPTION
[ Android ]

-> Version code will be calculated and set through pipeline for beta build using the git tag before building the app and not in build.gradle.
-> Added a place holder for version code.